### PR TITLE
Fix deprecation warning about pack name

### DIFF
--- a/module.json
+++ b/module.json
@@ -11,7 +11,7 @@
   "author": "DatDamnZotz [DatDamnZotz#7962]",
   "packs": [
     {
-      "name": "Game Audio Bundle 1 - Playlists 1",
+      "name": "GameAudioBundle1Playlists1",
       "label": "Game Audio Bundle 1 - Playlists 1",
       "path": "/packs/playlist1.db",
       "entity": "Playlist",


### PR DESCRIPTION
Fix a deprecation warning about wrong pack name:

The module "gAudioBundle-1" contains a pack with an invalid name "Game Audio Bundle 1 - Playlists 1". Pack names containing any character that is non-alphanumeric or an underscore will cease loading in version 14 of the software.